### PR TITLE
Version 1.1 

### DIFF
--- a/Asteroid.swiftpm/Package.swift
+++ b/Asteroid.swiftpm/Package.swift
@@ -8,13 +8,13 @@ import PackageDescription
 import AppleProductTypes
 
 let package = Package(
-    name: "Asteroid+",
+    name: "Asteroids+",
     platforms: [
         .iOS("15.2")
     ],
     products: [
         .iOSApplication(
-            name: "Asteroid+",
+            name: "Asteroids+",
             targets: ["AppModule"],
             bundleIdentifier: "com.choiysapple.AsteroidPlus",
             teamIdentifier: "ZW6466CHF4",
@@ -37,13 +37,13 @@ let package = Package(
             name: "AppModule",
             path: ".",
             resources: [
-                .copy("./Sound/WaveStart.wav"),
-                .copy("./Sound/ShipHit.wav"),
-                .copy("./Sound/LifeUp.wav"),
-                .copy("./Sound/Fire.wav"),
-                .copy("./Sound/BulletUp.wav"),
-                .copy("./Sound/AsteroidHit.wav")
-                       ]
+                .copy("Sound/WaveStart.wav"),
+                .copy("Sound/ShipHit.wav"),
+                .copy("Sound/LifeUp.wav"),
+                .copy("Sound/Fire.wav"),
+                .copy("Sound/BulletUp.wav"),
+                .copy("Sound/AsteroidHit.wav")
+            ]
         )
     ]
 )

--- a/Asteroid.swiftpm/Package.swift
+++ b/Asteroid.swiftpm/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["AppModule"],
             bundleIdentifier: "com.choiysapple.AsteroidPlus",
             teamIdentifier: "ZW6466CHF4",
-            displayVersion: "1.0",
+            displayVersion: "1.1",
             bundleVersion: "1",
             iconAssetName: "AppIcon",
             accentColorAssetName: "AccentColor",

--- a/Asteroid.swiftpm/Scene/GameScene.swift
+++ b/Asteroid.swiftpm/Scene/GameScene.swift
@@ -12,20 +12,25 @@ class GameScene: SKScene {
     
     // System data
     var score: Int = 0
-    var life: Int = 3
+    var life: Int = 1
     var wave: Int = 1
     var isGameOver: Bool = false
+    var isGameOverPopupOn: Bool = false
     var speedConstant = 1/kAsteroidSpeedConstant
-    var timePerFire: CFTimeInterval = 1.0           // Fire Cooltime
     
     // Physics Contact
     var contactQueue = [SKPhysicsContact]()
     
     // Fire
+    var timePerFire: CFTimeInterval = 1.0           // Fire Cooltime
     var timeOfLastFire: CFTimeInterval = 0.0
     var systemTime: CFTimeInterval = 1.0
     var isLoaded: Bool = true
-        
+    
+    // Game over popup delay
+    var timeRestartDelay: CFTimeInterval = 1.0
+    var timeOfGameOver: CFTimeInterval = 0.0
+
     override func didMove(to view: SKView) {
         
         configure()
@@ -64,7 +69,10 @@ extension GameScene {
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         
-        if isGameOver {
+        print("\(systemTime) \(timeOfGameOver) \(timeRestartDelay)")
+        
+        if isGameOver && (systemTime - timeOfGameOver > timeRestartDelay){
+            print("\(systemTime) \(timeOfGameOver) \(timeRestartDelay)")
             let gameScene = GameScene(size: self.size)
             self.view?.presentScene(gameScene, transition: .fade(withDuration: 1.0))
         }
@@ -470,9 +478,14 @@ extension GameScene {
         
         if life <= 0 {
             isGameOver = true
-            showPopUp()
-            removeHUD()
-            self.childNode(withName: kShipName)?.removeFromParent()
+            
+            if !isGameOverPopupOn {
+                showPopUp()
+                removeHUD()
+                self.childNode(withName: kShipName)?.removeFromParent()
+                isGameOverPopupOn = true
+                timeOfGameOver = systemTime
+            }
             
         } else if childNode(withName: kAsteroidName) == nil {
             wave += 1

--- a/Asteroid.swiftpm/Scene/MainMenuScene.swift
+++ b/Asteroid.swiftpm/Scene/MainMenuScene.swift
@@ -53,7 +53,7 @@ extension MainMenuScene {
         
         let titleLabel = SKLabelNode()
         titleLabel.fontName = "Avenir"
-        titleLabel.text = "Asteroid+"
+        titleLabel.text = "Asteroids+"
         titleLabel.horizontalAlignmentMode = .left
         titleLabel.verticalAlignmentMode = .bottom
         titleLabel.fontSize = 100


### PR DESCRIPTION
**1. Change Display Name**
from `Asteroid+` to `Asteroids+` 

**2. Disable `restart` for 1 seconds after game over**
This prevents Scoreboard disappears right away because of panic-clicking